### PR TITLE
Add Bedrock Engineer to solution list

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ GenU を 1 click でデプロイしたあとに、GenU のアップデートや�
 * AllowedIpV6AddressRanges
    * アクセス可能な IPv6 アドレス範囲を指定します
 
+## Bedrock Engineer
+
+[Bedrock Engineer](https://github.com/aws-samples/bedrock-engineer) は、Amazon Bedrock を活用した自律型ソフトウェア開発エージェントアプリケーションです。ファイル作成・編集、コマンド実行、Web検索、ナレッジベース活用、マルチエージェント連携、画像生成など、様々な機能をカスタマイズして利用できます。クライアントアプリケーションとして動作するため、CloudFormationによるデプロイは不要で、直接ダウンロードして使用できます。
+
+### ダウンロード
+
+[![GitHub Release](https://img.shields.io/github/v/release/aws-samples/bedrock-engineer)](https://github.com/aws-samples/bedrock-engineer/releases/latest)
+
 ## Technical Background
 
 AWS で動く多くのアプリケーションは [AWS CDK](https://aws.amazon.com/jp/cdk/) で開発されています。CDK で構築されたアプリケーションを動かすには AWS 環境への接続設定や Node.js のセットアップなど開発に関する知識が必要で、技術的知見がない方が生成 AI を試すために設定するのは困難でした。そのため、こちらのリポジトリでは AWS アカウントさえあれば 1 click 、難しい場合でも 1 command でデプロイ・検証できる体験を提供します。

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -181,6 +181,29 @@ Select an AWS solution and click Quick Launch. For more details, please refer to
   </div>
 </div>
 
+<div class="solution-card">
+  <div class="solution-card__image">
+    <!-- <img src="/assets/images/bedrock-engineer.png" alt="Bedrock Engineer Screenshot"> -->
+  </div>
+  <div class="solution-card__content">
+    <div class="solution-card__title">Bedrock Engineer</div>
+    <div class="solution-card__description">
+      <a href="https://github.com/aws-samples/bedrock-engineer" target="_blank">Bedrock Engineer</a> is an autonomous software development agent application powered by Amazon Bedrock. It offers various customizable features including file creation/editing, command execution, web search, knowledge base utilization, multi-agent collaboration, and image generation. As it operates as a client application, CloudFormation deployment is not required - you can download and use it directly.
+    </div>
+    <div class="solution-card__actions">
+      <div class="download-container">
+        <a href="https://github.com/aws-samples/bedrock-engineer/releases/latest" class="download-button md-button" target="_blank">
+          <i class="fa-solid fa-download"></i> Download
+        </a>
+      </div>
+      <a href="solutions/bedrock-engineer/" class="detail-button">
+        <i class="fa-solid fa-file-lines"></i>
+        User Guide
+      </a>
+    </div>
+  </div>
+</div>
+
 ## 3. Start Journey
 
 For Generative AI Use Cases, you can learn how to use it by following this workshop:

--- a/docs/index.md
+++ b/docs/index.md
@@ -181,6 +181,29 @@
   </div>
 </div>
 
+<div class="solution-card">
+  <div class="solution-card__image">
+    <!-- <img src="/assets/images/bedrock-engineer.png" alt="Bedrock Engineer Screenshot"> -->
+  </div>
+  <div class="solution-card__content">
+    <div class="solution-card__title">Bedrock Engineer</div>
+    <div class="solution-card__description">
+      <a href="https://github.com/aws-samples/bedrock-engineer" target="_blank">Bedrock Engineer</a> は、Amazon Bedrock を活用した自律型ソフトウェア開発エージェントアプリケーションです。ファイル作成・編集、コマンド実行、Web 検索、ナレッジベース活用、マルチエージェント連携、画像生成など、様々な機能をカスタマイズして利用できます。クライアントアプリケーションとして動作するため、直接ダウンロードして使用できます。
+    </div>
+    <div class="solution-card__actions">
+      <div class="download-container">
+        <a href="https://github.com/aws-samples/bedrock-engineer/releases/latest" class="download-button md-button" target="_blank">
+          <i class="fa-solid fa-download"></i>　Download Latest Release
+        </a>
+      </div>
+      <a href="solutions/bedrock-engineer/" class="detail-button">
+        <i class="fa-solid fa-file-lines"></i>
+        Deploy Guide
+      </a>
+    </div>
+  </div>
+</div>
+
 ## 3. Start Journey
 
 Generative AI Use Cases については、次のワークショップを進めることで使い方を学ぶことが出来ます。

--- a/docs/solutions/bedrock-engineer.en.md
+++ b/docs/solutions/bedrock-engineer.en.md
@@ -1,0 +1,78 @@
+# Bedrock Engineer
+
+[Bedrock Engineer](https://github.com/aws-samples/bedrock-engineer) is an autonomous software development agent application powered by Amazon Bedrock. It offers a rich set of features for AI-assisted development and content creation through a dedicated desktop application.
+
+## Overview
+
+Bedrock Engineer provides a standalone application experience with powerful AI capabilities:
+
+- 💬 Interactive chat interface with Amazon Nova, Claude, and Meta Llama models
+- 🛠️ Extensive tool integration for file operations, web search, code execution, and more
+- 🧠 Customizable agents for different use cases and specializations
+- 🌐 Agent Directory for sharing and discovering pre-configured agents
+- 🎤 Voice chat capabilities with Amazon Nova Sonic
+- 🖥️ Website and diagram generation features
+
+## Key Features
+
+### Agent Chat: Customizable AI Assistants
+
+The Agent Chat feature provides a powerful interface for interacting with AI assistants that can be fully customized to your needs:
+
+![Agent Chat](https://raw.githubusercontent.com/aws-samples/bedrock-engineer/main/assets/agent-chat-diagram.png)
+
+#### 1. Customizable Agents
+
+Create specialized agents by defining:
+- Custom names and descriptions
+- Tailored system prompts that define behavior and expertise
+- Tool selection specific to each agent's purpose
+
+![Custom Agents](https://raw.githubusercontent.com/aws-samples/bedrock-engineer/main/assets/custom-agents.png)
+
+#### 2. Integrated Tools
+
+Bedrock Engineer provides a comprehensive set of tools that can be selectively enabled for each agent:
+
+![Select Tools](https://raw.githubusercontent.com/aws-samples/bedrock-engineer/main/assets/select-tools.png)
+
+**File System Operations**
+- Create folders and files
+- Read and write file contents
+- List directory structures
+
+**Web & Search Operations**
+- Web search via Tavily API
+- Website content retrieval
+
+**Amazon Bedrock Integration**
+- Image generation and recognition
+- Video generation
+- Knowledge Base retrieval
+- Bedrock Agent and Flow integration
+
+**System Command & Code Execution**
+- Execute system commands
+- Run Python code in secure environments
+- Screen and camera capture
+
+#### 3. Agent Directory: Sharing and Discovery
+
+The Agent Directory allows you to discover and share AI agents created by the community:
+
+![Agent Directory](https://raw.githubusercontent.com/aws-samples/bedrock-engineer/main/assets/agent-directory.png)
+
+- Browse a curated collection of specialized agents
+- Search and filter by tags and capabilities
+- Add agents to your collection with one click
+- Contribute your custom agents to the community
+
+## Additional Resources
+
+- [GitHub Repository](https://github.com/aws-samples/bedrock-engineer)
+- [English Presentation Deck](https://speakerdeck.com/gawa/introducing-bedrock-engineer-en)
+- [Japanese Presentation Deck](https://speakerdeck.com/gawa/introducing-bedrock-engineer)
+
+## License
+
+This application is licensed under the MIT-0 License. See the [LICENSE](https://github.com/aws-samples/bedrock-engineer/blob/main/LICENSE) file for details.

--- a/docs/solutions/bedrock-engineer.md
+++ b/docs/solutions/bedrock-engineer.md
@@ -1,0 +1,79 @@
+# Bedrock Engineer
+
+[Bedrock Engineer](https://github.com/aws-samples/bedrock-engineer) は、[Amazon Bedrock](https://aws.amazon.com/bedrock/) を活用したソフトウェア開発タスクのための AI アシスタントです。大規模な言語モデルと実際のファイルシステム操作、Web検索機能などを含む自律的な AI エージェントがあなたの開発を支援します。
+
+## 概要
+
+Bedrock Engineer は、強力な AI 機能を備えたスタンドアロンアプリケーション体験を提供します：
+
+- 💬 Amazon Nova、Claude、Meta Llama モデルとのインタラクティブなチャットインターフェース
+- 🛠️ ファイル操作、Web 検索、コード実行などのための広範なツール統合
+- 🧠 様々なユースケースや専門分野に対応するカスタマイズ可能なエージェント
+- 🌐 事前設定されたエージェントを共有・発見するためのエージェントディレクトリ
+- 🎤 Amazon Nova Sonic によるボイスチャット機能
+- 🖥️ ウェブサイトや図の生成機能
+
+## 主な機能
+
+### エージェントチャット：カスタマイズ可能な AI アシスタント
+
+エージェントチャット機能は、ニーズに合わせて完全にカスタマイズできる AI アシスタントとのインタラクションのための強力なインターフェースを提供します：
+
+![エージェントチャット](https://raw.githubusercontent.com/aws-samples/bedrock-engineer/main/assets/agent-chat-diagram.png)
+
+#### 1. カスタマイズ可能なエージェント
+
+左上のメニューからエージェントを選択します。デフォルトでは汎用的なソフトウェア開発に特化した Software Developer, プログラミング学習を支援する Programming Mentor, サービスやプロダクトの構想段階を支援する Product Designer を搭載しています。
+
+![カスタムエージェント](https://raw.githubusercontent.com/aws-samples/bedrock-engineer/main/assets/custom-agents.png)
+
+エージェントの設定をカスタマイズします。エージェントの名前と説明を入力し、システムプロンプトを入力します。システムプロンプトはエージェントの振る舞いを決定する重要な要素です。エージェントの目的や規制事項、役割、使用できるツールと使うタイミングを明確にしておくことで、より適切な回答を得ることができます。
+
+#### 2. 統合ツール
+
+左下の Tools アイコンをクリックして、エージェントが使用できるツールを選択します。ツールはエージェントごとに個別に設定できます。
+
+![ツール選択](https://raw.githubusercontent.com/aws-samples/bedrock-engineer/main/assets/select-tools.png)
+
+**ファイルシステム操作**
+- フォルダとファイルの作成
+- ファイル内容の読み書き
+- ディレクトリ構造の一覧表示
+
+**Web & 検索操作**
+- Tavily API を使用した Web 検索
+- ウェブサイトコンテンツの取得
+
+**Amazon Bedrock 統合**
+- 画像生成と認識
+- ビデオ生成
+- ナレッジベース検索
+- Bedrock エージェントとフローの統合
+
+**システムコマンド & コード実行**
+- システムコマンドの実行
+- 安全な環境での Python コードの実行
+- 画面とカメラのキャプチャ
+
+#### 3. Agent Directory：共有と発見
+
+Agent Directoryは、優れたコントリビューターによって作成されたAIエージェントを発見してすぐに使用できるコンテンツハブです。様々なタスクや専門分野向けに設計された厳選済みのエージェントコレクションを提供しています。
+
+![Agent Directory](https://raw.githubusercontent.com/aws-samples/bedrock-engineer/main/assets/agent-directory.png)
+
+**機能**
+- **コレクションの閲覧** - コミュニティによって作成された専門的なエージェントの拡大するライブラリを探索
+- **検索とフィルタリング** - 検索機能またはタグによるフィルタリングを使用して、ニーズに合ったエージェントを素早く発見
+- **詳細情報の表示** - 各エージェントの作成者、システムプロンプト、対応ツール、使用シナリオなどの包括的な情報を確認
+- **ワンクリック追加** - ワンクリックで任意のエージェントを個人コレクションに追加し、すぐに使用開始
+- **エージェントの投稿** - コントリビューターになって、あなたのカスタムエージェントをコミュニティと共有
+
+## 追加リソース
+
+- [GitHub Repository](https://github.com/aws-samples/bedrock-engineer)
+- [英語プレゼンテーションデッキ](https://speakerdeck.com/gawa/introducing-bedrock-engineer-en)
+- [日本語プレゼンテーションデッキ](https://speakerdeck.com/gawa/introducing-bedrock-engineer)
+
+## ライセンス
+
+このアプリケーションは MIT-0 ライセンスの下でライセンスされています。詳細は [LICENSE](https://github.com/aws-samples/bedrock-engineer/blob/main/LICENSE) ファイルをご覧ください。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,4 +90,5 @@ nav:
     - 'Bedrock Chat': 'solutions/brchat.md'
     - 'GenAI Design Studio': 'solutions/genai-design-studio.md'
     - 'ComfyUI': 'solutions/comfyui.md'
+    - 'Bedrock Engineer': 'solutions/bedrock-engineer.md'
 #  - License: 'general/license.md'


### PR DESCRIPTION
This PR adds Bedrock Engineer to the solution list. 

Changes include:
- Added Bedrock Engineer section to README.md
- Added Bedrock Engineer card to docs/index.en.md
- Created documentation pages in English and Japanese (docs/solutions/bedrock-engineer.en.md and docs/solutions/bedrock-engineer.md)
- Updated mkdocs.yml to include Bedrock Engineer in the navigation

Bedrock Engineer is a client application that doesn't require CloudFormation deployment, so the documentation focuses on its key features: customizable agents, tool integration, and agent sharing capabilities.