### PR TITLE
Add instructions for deleting GenU to documentation

### DIFF
--- a/docs/solutions/generative-ai-use-cases-update.en.md
+++ b/docs/solutions/generative-ai-use-cases-update.en.md
@@ -1,4 +1,4 @@
-# GenU Updates and Parameter Changes
+# How to Update, Change Parameters, and Delete GenU
 This guide explains how to update GenU and change parameters after deploying with one-click deployment. For detailed parameters supported by GenU, please refer to the [GenU Documentation](https://aws-samples.github.io/generative-ai-use-cases/en/ABOUT.html).
 
 The following steps will be performed:  
@@ -301,3 +301,19 @@ npm run cdk:deploy:quick -- -c env=dev
 ```
 
 The update is now complete!
+
+## How to Delete GenU {#genu-delete}
+
+This section explains how to delete GenU using SageMaker Code Editor.
+
+After opening SageMaker Code Editor, open the GenU directory with Open Folder. Navigate to the git cloned directory in the terminal.  
+
+```shell
+cd /home/sagemaker-user/generative-ai-use-cases/
+```
+
+Delete GenU. The `env=dev` parameter specifies the Environment name you want to delete. The default is dev.  
+
+```shell
+npm run cdk:destroy -- -c env=dev
+```

--- a/docs/solutions/generative-ai-use-cases-update.md
+++ b/docs/solutions/generative-ai-use-cases-update.md
@@ -1,4 +1,5 @@
-# GenU のアップデートやパラメーター変更
+# GenU のアップデート、パラメーター変更、削除の方法
+
 GenU を 1 click でデプロイしたあとに、アップデートやパラメーター変更を行う方法を紹介します。GenU でサポートしている詳細なパラメーターは、[GenU のドキュメント](https://aws-samples.github.io/generative-ai-use-cases/ja/ABOUT.html)をご確認ください。
 
 以下のステップを行います。  
@@ -306,3 +307,19 @@ npm run cdk:deploy:quick -- -c env=dev
 ```
 
 これでアップデートが完了です！
+
+## GenU を削除する手順 {#genu-delete}
+
+SageMaker Code Editor を利用して、GenU を削除する手順を紹介します。
+
+SageMaker Code Editor を開いたあと、Open Folder で GenU のディレクトリを開きます。ターミナルで git clone をしたディレクトリに移動します。  
+
+```shell
+cd /home/sagemaker-user/generative-ai-use-cases/
+```
+
+GenU を削除します。`env=dev` のパラメーターは、デプロイしたい Environent 名を指定します。デフォルトでは dev です。  
+
+```shell
+npm run cdk:destroy -- -c env=dev
+```


### PR DESCRIPTION
This PR adds instructions for deleting GenU deployments to both the Japanese and English documentation.

Changes include:
- Updated the title of both documents to include deletion functionality
- Added a new section with step-by-step instructions for deleting GenU using SageMaker Code Editor
- Ensured consistency between Japanese and English versions

These instructions will help users who want to clean up their GenU deployments when they are no longer needed.