### PR TITLE
Fix/genaistudio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+*DS_Store*
 
 # C extensions
 *.so

--- a/README.md
+++ b/README.md
@@ -93,8 +93,6 @@ GenU を 1 click でデプロイしたあとに、GenU のアップデートや�
 
 * NotificationEmailAddress
    * デプロイの開始・終了を通知するメールアドレスです。
-* BedrockRegion (default: us-east-1)
-   * Amazon Bedrock Nova モデルを利用するリージョンです（us-east-1, us-west-2）
 * SelfSignUp (default: true)
    * セルフサインアップの有効 / 無効を切り替えます。
 * AllowedSignUpEmailDomains
@@ -185,8 +183,9 @@ graph TD
 aws-generative-ai-asset-box/
 ├── build/           # CloudFormation templates and scripts for deployment
 │   ├── genu/        
-│   ├── bedrock-cc/  # Comming Soon
-│   └── dify/        # Comming Soon
+│   ├── bedrock-cc/  
+│   └── dify/       
+│   ├── genstudio/  　
 ├── tests/           # Test for scripts
 ├── .venv/           # Python virtual environment (created by uv)
 ├── pyproject.toml   # Python project configuration

--- a/deployments/genstudio/GenStudioDeploymentStack.yaml
+++ b/deployments/genstudio/GenStudioDeploymentStack.yaml
@@ -163,6 +163,11 @@ Resources:
                   cdkJson.context.allowedIpV4AddressRanges = process.env.AllowedIpV4AddressRanges ? process.env.AllowedIpV4AddressRanges.split(',').map(r => r.trim()) : ["0.0.0.0/1", "128.0.0.0/1"];
                   cdkJson.context.allowedIpV6AddressRanges = process.env.AllowedIpV6AddressRanges ? process.env.AllowedIpV6AddressRanges.split(',').map(r => r.trim()) : ["0000:0000:0000:0000:0000:0000:0000:0000/1", "8000:0000:0000:0000:0000:0000:0000:0000/1"];
                   
+                  // Update deployment region to match the CodeBuild execution region
+                  const currentRegion = process.env.AWS_DEFAULT_REGION;
+                  console.log(`Setting deployment region to CodeBuild execution region: ${currentRegion}`);
+                  cdkJson.context.deploymentRegion = currentRegion;
+                  
                   fs.writeFileSync(cdkJsonPath, JSON.stringify(cdkJson, null, 2));
                   console.log('Updated cdk.json with deployment parameters');
                   console.log('Email domains:', JSON.stringify(cdkJson.context.allowedSignUpEmailDomains));

--- a/deployments/genstudio/GenStudioDeploymentStack.yaml
+++ b/deployments/genstudio/GenStudioDeploymentStack.yaml
@@ -180,7 +180,7 @@ Resources:
 
             build:
               commands:
-                - cd $CODEBUILD_SRC_DIR/sample-genai-design-studio
+                - cd $CODEBUILD_SRC_DIR/sample-genai-design-studio/cdk
                 
                 # Check if bootstrap is needed
                 - |
@@ -189,11 +189,11 @@ Resources:
                   
                   if [[ $BOOTSTRAP_EXISTS == *"Stack with id $BOOTSTRAP_STACK_NAME does not exist"* ]]; then
                     echo "Running CDK bootstrap..."
-                    cd cdk && npx cdk bootstrap
+                    npx cdk bootstrap
                   fi
                 
                 # Deploy the stack
-                - cd cdk && npx cdk deploy --all --require-approval never --asset-parallelism --asset-prebuild=false --concurrency 2 --method=direct
+                - npx cdk deploy --all --require-approval never --asset-parallelism --asset-prebuild=false --concurrency 2 --method=direct
                 
                 # Get deployment information using CloudFormation outputs
                 - cd $CODEBUILD_SRC_DIR/

--- a/deployments/genstudio/GenStudioDeploymentStack.yaml
+++ b/deployments/genstudio/GenStudioDeploymentStack.yaml
@@ -8,7 +8,6 @@ Metadata:
           default: "GenAI Design Studio Deployment Parameters"
         Parameters:
           - NotificationEmailAddress
-          - BedrockRegion
           - SelfSignUp
           - AllowedSignUpEmailDomains
           - AllowedIpV4AddressRanges
@@ -21,12 +20,7 @@ Parameters:
     AllowedPattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
     ConstraintDescription: Must be a valid email address
   
-  BedrockRegion:
-    Type: String
-    Default: us-east-1
-    AllowedValues: [us-east-1, us-west-2]
-    Description: AWS region for Amazon Bedrock Nova models (us-east-1 or us-west-2)
-  
+
   SelfSignUp:
     Type: String
     AllowedValues: [true, false]
@@ -121,8 +115,6 @@ Resources:
         Image: aws/codebuild/amazonlinux-x86_64-standard:5.0
         PrivilegedMode: true
         EnvironmentVariables:
-          - Name: BedrockRegion
-            Value: !Ref BedrockRegion
           - Name: SelfSignUp
             Value: !Ref SelfSignUp
           - Name: AllowedSignUpEmailDomains
@@ -213,14 +205,13 @@ Resources:
 
                   Important Next Steps:
                   1. Please enable Nova model access on Amazon Bedrock:
-                     https://${AWS_ACCOUNT_ID}.${BedrockRegion}.console.aws.amazon.com/bedrock/home?region=${BedrockRegion}#/modelaccess
+                     https://${AWS_ACCOUNT_ID}.${AWS_DEFAULT_REGION}.console.aws.amazon.com/bedrock/home?region=${AWS_DEFAULT_REGION}#/modelaccess
                      Required models: Nova Canvas, Nova Micro, Nova Lite
                   
                   2. Please create a user in the Cognito User Pool to access the application (if self-signup disabled):
                      ${USER_CREATION_URL}
 
                   Configuration:
-                  Bedrock Region: ${BedrockRegion}
                   Self-Signup Enabled: ${SelfSignUp}
                   Allowed SignUp Email Domains: ${AllowedSignUpEmailDomains}
                   Allowed IPv4 Address Ranges: ${AllowedIpV4AddressRanges}

--- a/docs/index.md
+++ b/docs/index.md
@@ -136,9 +136,8 @@
       <div class="deployment-container">
         <select class="region-selector">
           <option value="ap-northeast-1">東京</option>
-          <option value="ap-northeast-3">大阪</option>
           <option value="us-east-1">バージニア</option>
-          <option value="us-west-2">オレゴン</option>
+          <option value="eu-west-1">アイルランド</option>
         </select>
         <a href="https://ap-northeast-1.console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=GenStudioDeploymentStack&templateURL=https://aws-ml-jp.s3.ap-northeast-1.amazonaws.com/asset-deployments/GenStudioDeploymentStack.yaml" class="deployment-button md-button" target="_blank">
           <i class="fa-solid fa-rocket"></i>　Deploy

--- a/docs/solutions/genai-design-studio.en.md
+++ b/docs/solutions/genai-design-studio.en.md
@@ -22,7 +22,6 @@
 You can configure the following parameters during deployment:
 
 * **NotificationEmailAddress**: Email address to receive deployment start/completion notifications
-* **BedrockRegion** (default: us-east-1): Region for Amazon Bedrock Nova models (us-east-1, us-west-2)
 * **SelfSignUp** (default: true): Enable/disable self-signup functionality
 * **AllowedSignUpEmailDomains**: Allowed email domains for signup (comma-separated, e.g., example.co.jp)
 * **AllowedIpV4AddressRanges** (default: 0.0.0.0/1,128.0.0.0/1): Allowed IPv4 address ranges for access

--- a/docs/solutions/genai-design-studio.md
+++ b/docs/solutions/genai-design-studio.md
@@ -22,7 +22,6 @@
 デプロイ時に以下のパラメータを設定できます：
 
 * **NotificationEmailAddress**: デプロイの開始・終了を通知するメールアドレス
-* **BedrockRegion** (デフォルト: us-east-1): Amazon Bedrock Nova モデルを利用するリージョン（us-east-1, us-west-2）
 * **SelfSignUp** (デフォルト: true): セルフサインアップの有効/無効を切り替えます
 * **AllowedSignUpEmailDomains**: サインアップを許可するメールドメイン（カンマ区切り、例: example.co.jp）
 * **AllowedIpV4AddressRanges** (デフォルト: 0.0.0.0/1,128.0.0.0/1): アクセスを許可するIPv4アドレス範囲


### PR DESCRIPTION
*Issue*
cdk deploy時に以下のエラーが発生していた。

> VtoAppFrontendWafStack: SSM parameter /cdk-bootstrap/hnb659fds/version not found. Has the environment been bootstrapped? Please run 'cdk bootstrap' 

*Description of changes:*
genai-desing-studio の[このソースコード変更](https://github.com/aws-samples/sample-genai-design-studio/commit/023e4c198b0619241f1c1917101f571efebfb139)に伴い、code build 実行リージョンと cdk deploy リージョンが不一致かつ、cdk deploy 先リージョンで cdk bootstrap が実行されていない場合に本エラーが発生することが確認できたので、以下で修正対応しました

- CodeBuild の実行リージョンを取得してそのリージョンにdeployするようにcdk.jsonを更新。

*test:*

- 新規で作成したAWS環境にdeployしアプリが立ち上がることを確認。

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
