### PR TITLE
GenUの地域別モデル対応機能を追加

### DIFF
--- a/.amazonq/rules/deployment.md
+++ b/.amazonq/rules/deployment.md
@@ -181,7 +181,7 @@ fi
 
 ## Implementation Examples
 
-You can use `/workspace` directory for storing test scripts to confirm behavior or git clone target solution repository. This directory is excluded from commit by `.gitignore`.
+You can use `/.workspace` directory for storing test scripts to confirm behavior or git clone target solution repository. This directory is excluded from commit by `.gitignore`.
 
 ### Parameter Definition Example
 

--- a/deployments/genu/GenUDeploymentStack.yaml
+++ b/deployments/genu/GenUDeploymentStack.yaml
@@ -154,9 +154,9 @@ Resources:
         CloudWatchLogs:
           Status: ENABLED
       Environment:
-        Type: LINUX_CONTAINER
+        Type: ARM_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux-x86_64-standard:5.0
+        Image: aws/codebuild/amazonlinux2-aarch64-standard:3.0
         PrivilegedMode: false
         EnvironmentVariables:
           - Name: Environment
@@ -214,15 +214,77 @@ Resources:
                     echo "No existing parameters found in Parameter Store or UsePreviousDeploymentParameter=false. Using current parameters."
                   fi
 
-                # Create and run unified parameter script
+                # Create and run unified parameter script with model conversion
                 - |
-                  cat > update-params.js << 'EOF'
-                  const fs = require('fs');
+                  cat > update-params.mjs << 'EOF'
+                  import fs from 'fs';
+                  import { execSync } from 'child_process';
 
+                  // Model conversion functions
+                  async function getAvailableModels(region) {
+                    let inferenceProfiles = [];
+                    try {
+                      const profileResult = execSync(`aws bedrock list-inference-profiles --region ${region} --query "inferenceProfileSummaries[].inferenceProfileId" --output json`, { encoding: 'utf8' });
+                      inferenceProfiles = JSON.parse(profileResult);
+                    } catch (error) {
+                      console.log(`No inference profiles available in ${region}`);
+                    }
+                    
+                    const modelResult = execSync(`aws bedrock list-foundation-models --region ${region} --by-output-modality TEXT --query "modelSummaries[].modelId" --output json`, { encoding: 'utf8' });
+                    const foundationModels = JSON.parse(modelResult);
+                    
+                    return [...inferenceProfiles, ...foundationModels];
+                  }
+
+                  function findAvailableModel(originalModelId, availableModels) {
+                    const baseModelId = originalModelId.replace(/^(us|apac|eu)\./, '');
+
+                    if (availableModels.includes(originalModelId)) {
+                      return { modelId: originalModelId, converted: false, reason: 'Original available' };
+                    }
+                    
+                    const inferenceProfile = availableModels.find(modelId => 
+                      modelId !== baseModelId && 
+                      modelId.replace(/^(us|apac|eu)\./, '') === baseModelId
+                    );
+                    
+                    if (inferenceProfile) {
+                      return { modelId: inferenceProfile, converted: true, reason: 'Inference profile' };
+                    }
+                    
+                    if (availableModels.includes(baseModelId)) {
+                      return { modelId: baseModelId, converted: true, reason: 'In-region model' };
+                    }
+                    
+                    return { modelId: originalModelId, converted: false, reason: 'No matching model found' };
+                  }
+
+                  async function convertModels(modelIds, region) {
+                    const availableModels = await getAvailableModels(region);
+                    const results = [];                    
+                    
+                    for (const modelId of modelIds) {
+                      const result = findAvailableModel(modelId, availableModels);
+                      
+                      if (result.reason !== 'No matching model found') {
+                        results.push(result.modelId);
+                      }
+                      
+                      if (result.converted) {
+                        console.log(`✓ ${modelId} -> ${result.modelId} (${result.reason})`);
+                      } else if (result.reason === 'No matching model found') {
+                        console.log(`⚠ ${modelId} (${result.reason}) - FILTERED OUT`);
+                      } else {
+                        console.log(`✓ ${modelId} (${result.reason})`);
+                      }
+                    }
+                    
+                    return [...new Set(results)];
+                  }
+
+                  // Main parameter processing
                   const cdkJson = JSON.parse(fs.readFileSync('packages/cdk/cdk.json', 'utf8'));
                   const envName = process.env.Environment;
-                  
-                  // Read parameter mode
                   const usingExistingParams = process.env.UsePreviousDeploymentParameter === 'true';
                   
                   let params;
@@ -242,9 +304,14 @@ Resources:
                       additionalModelsStr.split(',').map(id => id.trim()) 
                       : [];
 
+                    const allModelIds = [...new Set([...additionalModelIds, ...cdkJson.context.modelIds])];
+                    
+                    // Convert models for the target region
+                    const convertedModelIds = await convertModels(allModelIds, modelRegion);
+
                     params = {
                       modelRegion: modelRegion,
-                      modelIds: [...new Set([...additionalModelIds, ...cdkJson.context.modelIds])],
+                      modelIds: convertedModelIds,
                       ragKnowledgeBaseEnabled: ragEnabled === 'Knowledge-Bases' || ragEnabled === 'Both' || ragEnabled === 'Both-Enterprise',
                       ragEnabled: ragEnabled === 'Kendra' || ragEnabled === 'Kendra-Enterprise' || ragEnabled === 'Both' || ragEnabled === 'Both-Enterprise',
                       selfSignUpEnabled: selfSignUp === 'true',
@@ -273,7 +340,7 @@ Resources:
                   console.log('DEBUG - Final params:', JSON.stringify(params, null, 2));
                   EOF
                   
-                  node update-params.js
+                  node update-params.mjs
                   
                   # Store the JSON as a single parameter with SecureString type
                   aws ssm put-parameter --name "/genu/${Environment}.json" \


### PR DESCRIPTION
## 概要
GenUデプロイメントに動的モデル変換機能を追加し、地域別のモデル可用性に自動対応できるようにしました。

## 変更内容
- **動的モデル変換ロジック**: USの推論プロファイルを地域別の同等モデル（APAC/EU）に自動変換
- **利用不可モデルのフィルタリング**: デプロイメント失敗を防ぐため、利用できないモデルを自動除外
- **aarch64アーキテクチャ対応**: ARM_CONTAINER環境でのサポートを追加
- **Node.js 22対応**: ES moduleシンタックス（.mjs）に更新

## 解決する問題
- ap-northeast-1等の非US地域でのGenUデプロイメント失敗
- 地域別のモデル可用性の違いによる手動設定の必要性
- 推論プロファイルの地域間互換性問題

## テスト結果
- ✅ ap-northeast-1でのデプロイメント成功確認
- ✅ us-east-1での既存機能維持確認
- ✅ モデル変換ロジックの動作確認

## 技術詳細
- AWS Bedrock APIを使用した動的モデル検索
- 優先順位ベースのモデル選択（オリジナル → 地域別推論プロファイル → 地域内モデル）
- 後方互換性を維持した実装

この変更により、GenUは全てのAWS地域で手動設定なしにデプロイ可能になります。