### PR TITLE
feat: Add AgentCoreEnabled parameter for AWS MCP integration

### DIFF
--- a/deployments/genu/GenUDeploymentStack.yaml
+++ b/deployments/genu/GenUDeploymentStack.yaml
@@ -12,6 +12,7 @@ Metadata:
           - ModelRegion
           - AdditionalModels
           - RAGEnabled
+          - AgentCoreEnabled
           - SelfSignUp
           - AllowedSignUpEmailDomains
           - AllowedIpV4AddressRanges
@@ -50,6 +51,12 @@ Parameters:
     AllowedValues: ["None", "Knowledge-Bases", "Kendra", "Kendra-Enterprise", "Both", "Both-Enterprise"]
     Default: "None"
     Description: 'Select RAG capabilities: Amazon Bedrock Knowledge Bases, Kendra, Kendra Enterprise Edition, or combinations of them.'
+  
+  AgentCoreEnabled:
+    Type: String
+    AllowedValues: [true, false]
+    Default: true
+    Description: 'Enable agent that work with AWS MCP run on AgentCore (runs on us-east-1)'
   
   SelfSignUp:
     Type: String
@@ -167,6 +174,8 @@ Resources:
             Value: !Ref AdditionalModels
           - Name: RAGEnabled
             Value: !Ref RAGEnabled
+          - Name: AgentCoreEnabled
+            Value: !Ref AgentCoreEnabled
           - Name: SelfSignUp
             Value: !Ref SelfSignUp
           - Name: AllowedSignUpEmailDomains
@@ -295,6 +304,7 @@ Resources:
                     const modelRegion = process.env.ModelRegion;
                     const additionalModelsStr = process.env.AdditionalModels;
                     const ragEnabled = process.env.RAGEnabled;
+                    const agentCoreEnabled = process.env.AgentCoreEnabled;
                     const selfSignUp = process.env.SelfSignUp;
                     const allowedSignUpEmailDomains = process.env.AllowedSignUpEmailDomains;
                     const allowedIpV4AddressRanges = process.env.AllowedIpV4AddressRanges;
@@ -314,6 +324,8 @@ Resources:
                       modelIds: convertedModelIds,
                       ragKnowledgeBaseEnabled: ragEnabled === 'Knowledge-Bases' || ragEnabled === 'Both' || ragEnabled === 'Both-Enterprise',
                       ragEnabled: ragEnabled === 'Kendra' || ragEnabled === 'Kendra-Enterprise' || ragEnabled === 'Both' || ragEnabled === 'Both-Enterprise',
+                      createGenericAgentCoreRuntime: agentCoreEnabled === 'true',
+                      agentCoreRegion: 'us-east-1',
                       selfSignUpEnabled: selfSignUp === 'true',
                       allowedSignUpEmailDomains: allowedSignUpEmailDomains ? allowedSignUpEmailDomains.split(',').map(d => d.trim()) : null,
                       allowedIpV4AddressRanges: allowedIpV4AddressRanges ? allowedIpV4AddressRanges.split(',').map(r => r.trim()) : null,
@@ -421,6 +433,7 @@ Resources:
                   Model Region: ${ModelRegion}
                   RAG Enabled: ${RAGEnabled}
                   Kendra Edition: $([[ "${RAGEnabled}" == *"Enterprise"* ]] && echo "Enterprise" || echo "Developer")
+                  Agent Core Enabled: ${AgentCoreEnabled}
                   Self-Signup Enabled: ${SelfSignUp}
                   Allowed SignUp Email Domains: ${AllowedSignUpEmailDomains}
                   Allowed IpV4 Address Ranges: ${AllowedIpV4AddressRanges}

--- a/docs/solutions/generative-ai-use-cases.en.md
+++ b/docs/solutions/generative-ai-use-cases.en.md
@@ -19,9 +19,11 @@ You can configure the following parameters during deployment:
 * **NotificationEmailAddress**
     * Email address for receiving notifications about deployment start and completion
 * **ModelRegion**
-    * The region where Amazon Bedrock models will be used
+    * The region where Amazon Bedrock provides models. If specified models are not available in the selected region, they will be automatically converted to compatible models
 * **RAGEnabled** (default: None)
     * Select RAG capabilities to enable. "Knowledge-Bases" uses Amazon Bedrock Knowledge Bases, "Kendra" uses Amazon Kendra Developer Edition, and "Both" uses both. Options with "Enterprise" suffix (like "Kendra-Enterprise") use Kendra Enterprise Edition
+* **AgentCoreEnabled** (default: true)
+    * Enable agent functionality that works with AWS MCP on AgentCore (runs on us-east-1)
 * **SelfSignUp** (default: false)
     * Toggles self-signup functionality on/off
 * **AllowedSignUpEmailDomains**

--- a/docs/solutions/generative-ai-use-cases.md
+++ b/docs/solutions/generative-ai-use-cases.md
@@ -19,9 +19,11 @@
 * **NotificationEmailAddress**
     * デプロイの開始・終了を通知するメールアドレスです
 * **ModelRegion**
-    * Amazon Bedrock のモデルを利用するリージョンです
+    * Amazon Bedrock のモデルを提供するリージョンです。GenU で利用するモデルが指定されたリージョンで提供されていない場合、互換性のあるモデルに自動的に変換されます
 * **RAGEnabled** (デフォルト: None)
     * RAG の設定を選択します。"Knowledge-Bases" は Amazon Bedrock Knowledge Bases 、"Kendra" は Amazon Kendra Developer Edition 、"Both" は両方使用します。"Kendra-Enterprise" のように "Enterprise" では Enterprise Edition を使用します
+* **AgentCoreEnabled** (デフォルト: true)
+    * AWS MCP と連携するエージェント機能を有効にします（us-east-1 で実行されます）
 * **SelfSignUp** (デフォルト: false)
     * セルフサインアップの有効 / 無効を切り替えます
 * **AllowedSignUpEmailDomains**


### PR DESCRIPTION
## Summary
Add AgentCoreEnabled parameter to GenU deployment template to enable agent functionality with AWS MCP integration.

## Changes
- Add AgentCoreEnabled parameter (default: true) to CloudFormation template
- Configure createGenericAgentCoreRuntime and agentCoreRegion when enabled
- Set agentCoreRegion to us-east-1 for Amazon Nova Canvas MCP compatibility
- Update deployment notification to show Agent Core status

## Testing
- Successfully deployed and tested with AgentCoreEnabled=true
- Confirmed AgentCore runtime creation in us-east-1
- Verified parameter processing and notification updates

## Related
Enables agent functionality that works with AWS MCP on AgentCore, specifically supporting Amazon Nova Canvas MCP which requires us-east-1 region.