### PR TITLE
feat(kiro-ide): add optional AdministratorAccess for CDK deployments

### DIFF
--- a/deployments/kiro-ide/KiroIDEDeploymentStack.yaml
+++ b/deployments/kiro-ide/KiroIDEDeploymentStack.yaml
@@ -14,6 +14,7 @@ Metadata:
           - HomeFolder
           - RepoUrl
           - Language
+          - EnableAdministratorAccess
 
 Parameters:
   UserEmail:
@@ -44,6 +45,16 @@ Parameters:
     AllowedValues:
       - EN
       - JP
+  EnableAdministratorAccess:
+    Type: String
+    Default: 'false'
+    Description: Attach AdministratorAccess policy to instance role (required for CDK deployments)
+    AllowedValues:
+      - 'true'
+      - 'false'
+
+Conditions:
+  HasAdministratorAccess: !Equals [!Ref EnableAdministratorAccess, 'true']
 
 Mappings:
   CloudFrontPrefixListID:
@@ -279,6 +290,10 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
         - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+        - !If
+          - HasAdministratorAccess
+          - arn:aws:iam::aws:policy/AdministratorAccess
+          - !Ref AWS::NoValue
       Policies:
         - PolicyName: DCVLicenseAccess
           PolicyDocument:


### PR DESCRIPTION
Add EnableAdministratorAccess parameter (default: false) that conditionally attaches AdministratorAccess managed policy to the EC2 instance role, enabling CDK bootstrap and deploy from the IDE.

https://claude.ai/code/session_01R7mnjkDzVGQB6DCBiJeZdS

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
