### PR TITLE
fix(kiro-ide): wait for SSM agent registration before SendCommand

### DIFF
--- a/deployments/kiro-ide/KiroIDEDeploymentStack.yaml
+++ b/deployments/kiro-ide/KiroIDEDeploymentStack.yaml
@@ -936,12 +936,13 @@ Resources:
                       infos = resp.get('InstanceInformationList', [])
                       if infos and infos[0].get('PingStatus') == 'Online':
                           return
-                  except botocore.exceptions.ClientError:
+                  except botocore.exceptions.ClientError as e:
                       # Tolerate transient errors during the registration window
                       # (e.g. IAM role propagation lag, eventually-consistent SSM
                       # inventory). No SSM waiter exists for this state.
                       # See: https://github.com/aws/aws-cli/issues/4006
-                      pass
+                      code = e.response.get('Error', {}).get('Code', 'Unknown')
+                      print(f"[wait_for_ssm_online] transient {code}: {e}")
                   time.sleep(interval)
               raise TimeoutError(
                   f"Instance {instance_id} did not register with SSM within {timeout}s")
@@ -997,8 +998,11 @@ Resources:
                 Action:
                   - ssm:SendCommand
                   - ssm:DescribeInstanceInformation
-                  - secretsmanager:GetSecretValue
                 Resource: '*'
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource: !Ref UserCredentials
 
   # SNS Topic for Notifications
   DeploymentNotificationTopic:

--- a/deployments/kiro-ide/KiroIDEDeploymentStack.yaml
+++ b/deployments/kiro-ide/KiroIDEDeploymentStack.yaml
@@ -916,7 +916,7 @@ Resources:
     Properties:
       Runtime: python3.13
       MemorySize: 128
-      Timeout: 600
+      Timeout: 900
       Architectures: [x86_64]
       Handler: index.lambda_handler
       Role: !GetAtt RunSSMDocLambdaRole.Arn
@@ -924,7 +924,27 @@ Resources:
         ZipFile: |
           import cfnresponse
           import boto3
-          import json
+          import botocore
+          import time
+
+          def wait_for_ssm_online(ssm, instance_id, timeout=600, interval=10):
+              deadline = time.time() + timeout
+              while time.time() < deadline:
+                  try:
+                      resp = ssm.describe_instance_information(
+                          Filters=[{'Key': 'InstanceIds', 'Values': [instance_id]}])
+                      infos = resp.get('InstanceInformationList', [])
+                      if infos and infos[0].get('PingStatus') == 'Online':
+                          return
+                  except botocore.exceptions.ClientError:
+                      # Tolerate transient errors during the registration window
+                      # (e.g. IAM role propagation lag, eventually-consistent SSM
+                      # inventory). No SSM waiter exists for this state.
+                      # See: https://github.com/aws/aws-cli/issues/4006
+                      pass
+                  time.sleep(interval)
+              raise TimeoutError(
+                  f"Instance {instance_id} did not register with SSM within {timeout}s")
 
           def lambda_handler(event, context):
               if event['RequestType'] != 'Create':
@@ -944,7 +964,10 @@ Resources:
                            if k not in ['ServiceToken', 'InstanceId', 'DocumentName', 'SecretArn']}
                   params['UserPassword'] = [password]
 
-                  response = boto3.client('ssm').send_command(
+                  ssm = boto3.client('ssm')
+                  wait_for_ssm_online(ssm, props['InstanceId'])
+
+                  response = ssm.send_command(
                       InstanceIds=[props['InstanceId']],
                       DocumentName=props['DocumentName'],
                       Parameters=params)
@@ -973,6 +996,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - ssm:SendCommand
+                  - ssm:DescribeInstanceInformation
                   - secretsmanager:GetSecretValue
                 Resource: '*'
 


### PR DESCRIPTION
## Summary

`KiroIDEDeploymentStack` の `RunSSMDocLambda` が、EC2 が CREATE_COMPLETE になった直後に `ssm:SendCommand` を呼ぶため、SSM Agent の登録完了と race して `InvalidInstanceId` で失敗するケースを修正します。

Fixes #92

## Root Cause

- `Instance` リソースに `CreationPolicy` / `cfn-signal` が無いため、CloudFormation の CREATE_COMPLETE は EC2 が "running" になった瞬間に立つ。
- Ubuntu 24.04 の SSM Agent (snap 経由) は登録に数十秒〜数分かかる。
- `RunSSMDocLambda` は登録完了を待たずに `send_command` を発行し、`InvalidInstanceId` で失敗 → カスタムリソース失敗 → スタック ROLLBACK。

## Solution

`RunSSMDocLambda` 内で `send_command` の前に `describe_instance_information` をポーリングし、`PingStatus == "Online"` を確認してから SendCommand を実行する。

- ポーリング上限: 600 秒 (10 分)
- ポーリング間隔: 10 秒
- `ClientError` は許容して継続 (IAM 伝搬遅延等の一時エラー対策)。エラーコードと詳細を CloudWatch Logs に出力し、根本原因 (例: AccessDenied) を即時に可視化
- Lambda Timeout を 600s → 900s (Lambda 最大値) に拡張し、ポーリング後の処理および失敗時の `cfnresponse.FAILED` 送信のマージンを確保
- `RunSSMDocLambdaRole` に `ssm:DescribeInstanceInformation` を追加。`secretsmanager:GetSecretValue` は `Resource: '*'` から `!Ref UserCredentials` に絞って最小権限化

## Alternatives Considered

### 1. `CreationPolicy` + `cfn-signal` (採用せず)

UserData 側で `cfn-signal` を投げ、シグナル受信まで Instance の CREATE_COMPLETE を保留する CloudFormation 公式推奨パターン。

**不採用理由**: Ubuntu 24.04 のデフォルト Python は 3.12 で、`aws-cfn-bootstrap-py3-latest.tar.gz` が未対応。回避には Python 3.11 の virtualenv 構築 + pip インストール + symlink 設定が必要となり、UserData が肥大化し将来の Python バージョン変更にも壊れやすい。
- 参考: [cfn-init issue on Ubuntu 24.04 AMI](https://repost.aws/questions/QUYnAVjOxmTm-kF7uHYwlFtg/cfn-init-issue-on-ubuntu-24-04-ami)

### 2. SSM State Manager / Association (採用せず)

`AWS::SSM::Association` を使い、宣言的にインスタンスへドキュメントを適用するアプローチ。SSM 側がインスタンス登録を待ってから実行するため待機ロジック不要。

**不採用理由**: 既存の Lambda カスタムリソース (Secrets Manager からのパスワード解決 + CloudFormation への Password 出力) を廃止する大きな構造変更が必要。Issue 修正のスコープを超える。

### 3. SendCommand 側のリトライのみ (採用せず)

事前ポーリング無しで `InvalidInstanceId` 発生時に `send_command` をリトライする方式。

**不採用理由**: 最大 10 分のリトライをエラーハンドリングに組み込むのは制御フローが複雑になる。AWS re:Post でも事前の `describe_instance_information` ポーリングが標準回答として案内されており、明確に意図を表すコードになる。
- 参考: [Invalid Instance ID error - AWS re:Post](https://repost.aws/questions/QU4Bfuw6UsT7W7G51HlDO1uw/invalid-instance-id-error)

## Why Polling

`boto3` / AWS CLI には「SSM Agent が Online になるまで待つ」公式 waiter は存在しない ([aws/aws-cli#4006](https://github.com/aws/aws-cli/issues/4006) で 2019 年からの未解決要望)。AWS 公式ブログ・ドキュメント・サポート回答のいずれも `describe_instance_information` を間隔ポーリングする方法を案内しており、本 PR もその標準パターンに従う。

## Test Plan

- [x] `aws cloudformation validate-template --template-body file://deployments/kiro-ide/KiroIDEDeploymentStack.yaml`
- [x] ap-northeast-1 でスタックをデプロイし、`RunSSMDoc` が成功することを確認 — `RunSSMDoc` 02:21:07 CREATE_COMPLETE、Lambda Duration 13.3s で `PingStatus=Online` を待機後 SendCommand 成功
- [x] `/aws/lambda/<RunSSMDocLambda>` のログで polling が走っていることを確認 — Lambda ログから `wait_for_ssm_online` 経由で SUCCESS 応答 (CommandId 取得) を確認
- [x] 既存の Kiro IDE デプロイ機能 (DCV アクセス、認証) に regression がないことを確認 — DCV/EC2 経由で Kiro IDE が動作することを実機確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
